### PR TITLE
[Bugfix] Fixed Windows path issue

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,8 @@ export default async function() {
 		return fetch(uri.toString()).then((response) => response.arrayBuffer()).then((BINARY) => builder(BINARY));
 	}
 	const fs = await import("fs");
-	const buffer = fs.readFileSync(uri.pathname);
+	const url = await import("url");
+	const buffer = fs.readFileSync(url.fileURLToPath(uri.toString()));
 	return builder(buffer);
 }
 


### PR DESCRIPTION
On windows, `URL.pathname` adds a `/` in front of the drive. This makes it an invalid path an breaks the wasm loading. An easy fix is to use the node builtin url library to parse the uri to a pathname.